### PR TITLE
Fix theme validation logic causing incorrect warnings

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -51,7 +51,7 @@ if (themeMode === 'light-dark-auto' && siteConfig.themes.include.length < 2) {
 }
 let defaultTheme = siteConfig.themes.default || siteConfig.themes.include[0]
 let includedThemes = siteConfig.themes.include as string[]
-const themeNotIncluded = includedThemes.includes(defaultTheme)
+const themeNotIncluded = !includedThemes.includes(defaultTheme)
 if (
   (themeMode !== 'light-dark-auto' && themeNotIncluded) ||
   (themeMode === 'light-dark-auto' && defaultTheme !== 'auto' && themeNotIncluded)


### PR DESCRIPTION
## Problem
  The current theme validation logic in `src/layouts/Layout.astro` has inverted boolean logic that causes false warnings when the default
  theme actually exists in the `themes.include` array.

  ## Root Cause
  Line 54: `const themeNotIncluded = includedThemes.includes(defaultTheme)`

  The variable name suggests "not included" but `includes()` returns `true` when the theme is included, causing the warning to trigger incorrectly.

  ## Solution
  Fixed by adding negation operator: `const themeNotIncluded = !includedThemes.includes(defaultTheme)`

  ## Testing
  - Verified that warnings no longer appear when default theme exists in include array
  - Confirmed warnings still appear when theme is genuinely missing

  Fixes the console warning: `Default theme "dracula" not found in themes. Using first theme: "dracula".`