### PR TITLE
Making the use of descriptions more consistent

### DIFF
--- a/src/components/PostPreview.astro
+++ b/src/components/PostPreview.astro
@@ -14,7 +14,7 @@ interface Props {
 const { post } = Astro.props
 
 const { remarkPluginFrontmatter } = await render(post)
-const description = remarkPluginFrontmatter.description || post.data.description
+const description = remarkPluginFrontmatter.description
 let tags: Collation<'posts'>[] | undefined
 if (post.data.tags && post.data.tags.length > 0) {
   const tagsGroup = await TagsGroup.build()

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -31,7 +31,8 @@ export const getStaticPaths = (async () => {
 
 const { post, prev, next } = Astro.props
 const postData = post.data
-const { headings, Content: PostContent } = await render(post)
+const { headings, Content: PostContent, remarkPluginFrontmatter } = await render(post)
+const description = remarkPluginFrontmatter.description
 const addendum = await getCollection('addendum')
 let AddendumContent
 let addendumAvatarImage
@@ -68,7 +69,7 @@ if (postData.tags && postData.tags.length > 0) {
 
 <Layout
   title={postData.title}
-  description={postData.description}
+  description={description}
   author={postData.author}
   tags={postData.tags}
 >

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -23,6 +23,8 @@ export async function GET(_context: AstroGlobal) {
     items: posts.map((post) => ({
       title: post.data.title,
       pubDate: post.data.published,
+      // TODO this is not consistent with the `remarkDescription` plugin
+      // should we render the post here as well?
       description: post.data.description,
       author: post.data.author || siteConfig.author,
       link: `/posts/${post.id}`,


### PR DESCRIPTION
Fixing a discrepancy in the post description when rendering the post. It now uses `remarkPluginFrontmatter`'s output.

The `remarkPluginFrontMatter` plugin already uses the post's own description, so there's no need to fallback in other places.

The RSS feed is still inconsistent, see the TODO comment.